### PR TITLE
Update URL to download vagrant deb package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download Vagrant
-  get_url: url=https://dl.bintray.com/mitchellh/vagrant/vagrant_{{ vagrant_version }}_{{ vagrant_arch }}.deb
+  get_url: url=https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/vagrant_{{ vagrant_version }}_{{ vagrant_arch }}.deb
            dest=/usr/local/src/vagrant_{{ vagrant_version }}_{{ vagrant_arch }}.deb
 
 - name: Install Vagrant


### PR DESCRIPTION
Hey, all.

I've noticed that url to download vagrant deb package was updated.

This PR fixes it.
